### PR TITLE
Changed name of event from "clickedNode" to "mouseoverNode"

### DIFF
--- a/inst/htmlwidgets/rcytoscapejs.js
+++ b/inst/htmlwidgets/rcytoscapejs.js
@@ -271,6 +271,69 @@ HTMLWidgets.widget({
                         }
                     });
                 });
+                
+                cy.on('tap', 'node', function (event) {
+                    var node = this;
+                    Shiny.onInputChange("clickedNode", this._private.data.id);
+                    
+                    $(".qtip").remove();
+                    //console.log(event);
+                    
+                    var name = node.data("name"); 
+                    var href = node.data("href"); 
+                    var tooltip = node.data("tooltip"); 
+                    console.log("href: " + href);
+                    console.log("tooltip: " + tooltip);
+
+                    var target = event.cyTarget;
+                    var sourceName = target.data("id");
+                    var targetName = target.data("href");
+                    console.log(sourceName);
+                    //console.log(targetName);
+
+                    var x = event.cyRenderedPosition.x;
+                    var y = event.cyRenderedPosition.y;
+                    //var x = event.cyPosition.x;
+                    //var y = event.cyPosition.y;
+                    //console.log("x="+x+" Y="+y);
+
+                    cy.getElementById(node.id()).qtip({
+                        content: {
+                            text: function (event, api) {
+                              // Retrieve content from custom attribute of the $('.selector') elements.
+                              if(typeof(tooltip) === "undefined") {
+                                return name;
+                              } else {
+                                return tooltip;  
+                              }
+                            }
+                        },
+                        show: {
+                            ready: true
+                        },
+                        position: {
+                            my: 'top center',
+                            at: 'bottom center',
+                            adjust: {
+                              cyViewport: true
+                            },
+                            effect: false
+                        },
+                        hide: {
+                            fixed: true,
+                            event: false,
+                            inactive: 2000
+                        },
+                        style: {
+                            classes: 'qtip-bootstrap',
+                            tip: {
+                              width: 16,
+                              height: 8
+                            }
+                        }
+                    });
+                });
+                
             }
         });
     }

--- a/inst/htmlwidgets/rcytoscapejs.js
+++ b/inst/htmlwidgets/rcytoscapejs.js
@@ -212,7 +212,7 @@ HTMLWidgets.widget({
                 
                 cy.on('mouseover', 'node', function (event) {
                     var node = this;
-                    Shiny.onInputChange("clickedNode", this._private.data.id);
+                    Shiny.onInputChange("mouseoverNode", this._private.data.id);
                     
                     $(".qtip").remove();
                     //console.log(event);

--- a/r-cytoscape.js.Rproj
+++ b/r-cytoscape.js.Rproj
@@ -1,0 +1,17 @@
+Version: 1.0
+
+RestoreWorkspace: Default
+SaveWorkspace: Default
+AlwaysSaveHistory: Default
+
+EnableCodeIndexing: Yes
+UseSpacesForTab: Yes
+NumSpacesForTab: 2
+Encoding: UTF-8
+
+RnwWeave: Sweave
+LaTeX: pdfLaTeX
+
+BuildType: Package
+PackageUseDevtools: Yes
+PackageInstallArgs: --no-multiarch --with-keep.source


### PR DESCRIPTION
* Naming made no sense; when listening for a "mouseover" event, call it "mouseoverNode" in Shiny